### PR TITLE
Use validator method instead of ValidateType, Added onDispose property

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,8 +42,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 await Navigator.of(context).push(
                   MaterialPageRoute(
                     builder: (context) => AiBarcodeScanner(
-                      validateText: 'https://', // link to be validated
-                      validateType: ValidateType.startsWith,
+                      validator: (value) {
+                        return value.startsWith('https://');
+                      },
                       canPop: false,
                       onScan: (String value) {
                         debugPrint(value);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,6 +53,9 @@ class _MyHomePageState extends State<MyHomePage> {
                         });
                       },
                       onDetect: (p0) {},
+                      onDispose: () {
+                        debugPrint("Barcode scanner disposed!");
+                      },
                       controller: MobileScannerController(
                         detectionSpeed: DetectionSpeed.noDuplicates,
                       ),

--- a/lib/src/ai_barcode_scanner.dart
+++ b/lib/src/ai_barcode_scanner.dart
@@ -127,6 +127,9 @@ class AiBarcodeScanner extends StatefulWidget {
   /// The function that signals when the barcode scanner is started.
   final void Function(MobileScannerArguments?)? onScannerStarted;
 
+  /// Called when this object is removed from the tree permanently.
+  final void Function()? onDispose;
+
   /// if set barcodes will only be scanned if they fall within this [Rect]
   /// useful for having a cut-out overlay for example. these [Rect]
   /// coordinates are relative to the widget size, so by how much your
@@ -173,6 +176,7 @@ class AiBarcodeScanner extends StatefulWidget {
     this.errorBuilder,
     this.placeholderBuilder,
     this.onScannerStarted,
+    this.onDispose,
     this.scanWindow,
     this.startDelay,
     this.hintWidget,
@@ -203,6 +207,10 @@ class _AiBarcodeScannerState extends State<AiBarcodeScanner> {
   void dispose() {
     controller.dispose();
     super.dispose();
+
+    if (widget.onDispose != null) {
+      widget.onDispose!();
+    }
   }
 
   @override

--- a/lib/src/ai_barcode_scanner.dart
+++ b/lib/src/ai_barcode_scanner.dart
@@ -19,11 +19,16 @@ class AiBarcodeScanner extends StatefulWidget {
 
   /// Validate barcode text with [ValidateType]
   /// [validateText] and [validateType] must be set together.
+  @Deprecated('Use [validator] instead.')
   final String? validateText;
 
   /// Validate type [ValidateType]
   /// Validator working with single string value only.
+  @Deprecated('Use [validator] instead.')
   final ValidateType? validateType;
+
+  /// Validate barcode text with a function
+  final bool Function(String value)? validator;
 
   /// Set to false if you don't want duplicate barcode to be detected
   final bool allowDuplicates;
@@ -119,7 +124,7 @@ class AiBarcodeScanner extends StatefulWidget {
   /// If this is null, a black [ColoredBox] is used as placeholder.
   final Widget Function(BuildContext, Widget?)? placeholderBuilder;
 
-  ///The function that signals when the barcode scanner is started.
+  /// The function that signals when the barcode scanner is started.
   final void Function(MobileScannerArguments?)? onScannerStarted;
 
   /// if set barcodes will only be scanned if they fall within this [Rect]
@@ -138,8 +143,7 @@ class AiBarcodeScanner extends StatefulWidget {
   const AiBarcodeScanner({
     Key? key,
     required this.onScan,
-    this.validateText,
-    this.validateType,
+    this.validator,
     this.allowDuplicates = false,
     this.fit = BoxFit.cover,
     this.controller,
@@ -172,6 +176,8 @@ class AiBarcodeScanner extends StatefulWidget {
     this.scanWindow,
     this.startDelay,
     this.hintWidget,
+    @Deprecated('Use [validator] instead.') this.validateText,
+    @Deprecated('Use [validator] instead.') this.validateType,
   })  : assert(validateText == null || validateType != null),
         assert(validateText != null || validateType == null),
         super(key: key);
@@ -243,29 +249,33 @@ class _AiBarcodeScannerState extends State<AiBarcodeScanner> {
             key: widget.key,
             onDetect: (BarcodeCapture barcode) async {
               widget.onDetect?.call(barcode);
+
               if (barcode.barcodes.isEmpty) {
                 debugPrint('Failed to scan Barcode');
                 return;
               }
-              if (widget.validateText?.isNotEmpty == true) {
-                if (!widget.validateType!.toValidateTypeBool(
-                  barcode.barcodes.first.rawValue ?? "",
-                  widget.validateText!,
-                )) {
-                  HapticFeedback.heavyImpact();
-                  final String code = barcode.barcodes.first.rawValue!;
-                  debugPrint('Invalid Barcode => $code');
-                  _isSuccess = false;
-                  setState(() {});
-                  return;
-                }
+
+              final String code = barcode.barcodes.first.rawValue ?? "";
+
+              if ((widget.validator != null && !widget.validator!(code)) ||
+                  (widget.validateText?.isNotEmpty == true &&
+                      !widget.validateType!.toValidateTypeBool(
+                        code,
+                        widget.validateText!,
+                      ))) {
+                HapticFeedback.heavyImpact();
+                debugPrint('Invalid Barcode => $code');
+                _isSuccess = false;
+                setState(() {});
+                return;
               }
+
               _isSuccess = true;
               HapticFeedback.lightImpact();
-              final String code = barcode.barcodes.first.rawValue!;
               debugPrint('Barcode rawValue => $code');
               widget.onScan(code);
               setState(() {});
+
               if (widget.canPop && mounted && Navigator.canPop(context)) {
                 Navigator.pop(context);
               }


### PR DESCRIPTION
- Added `validator` property
- Added `onDispose` property #36
- `validateText` is deprecated
- `validateType` is deprecated

```dart
AiBarcodeScanner(
  validator: (value) {
    return value.startsWith('https://');
  },
  onDispose: () {
    debugPrint("Barcode scanner disposed!");
  },
);
```